### PR TITLE
Fix Windows crash: add __main__ guard for multiprocessing

### DIFF
--- a/Mo2oM.py
+++ b/Mo2oM.py
@@ -5,7 +5,6 @@ from os import makedirs, walk, path, pathsep
 from subprocess import run
 from json import load, dump
 import shutil
-import multiprocessing as mp
 
 parser = ArgumentParser(
     prog='python Mo2oM.py',
@@ -147,5 +146,4 @@ def main():
             dump(output, output_file, indent=2)
 
 if __name__ == "__main__":
-    mp.freeze_support()
     main()

--- a/Mo2oM.py
+++ b/Mo2oM.py
@@ -5,7 +5,7 @@ from os import makedirs, walk, path, pathsep
 from subprocess import run
 from json import load, dump
 import shutil
-
+import multiprocessing as mp
 
 parser = ArgumentParser(
     prog='python Mo2oM.py',
@@ -34,113 +34,118 @@ parser.add_argument("--use-tf-idf", dest="use_tf_idf", action="store_true",
 parser.add_argument("--hard-clustering", dest="hard_clustering", action="store_true",
                     help="Use argmax instead of a threshold value to extract microservice from the membership matrix to simulate hard clustering.")
 
-args = parser.parse_args()
 
-if not (args.file_path or args.project_directory):
-    parser.print_help()
-    print("\nerror: one of the following arguments are required: --file, --project")
-    exit()
-
-if args.evaluation_measure:
-    if bool(args.k) != ("SR" in args.evaluation_measure):
+def main():
+    args = parser.parse_args()
+    if not (args.file_path or args.project_directory):
         parser.print_help()
-        print("\nerror: The SR evaluation measure and the -k flag should always be used together to specify the k value for the SR measure. (e.g. -e SR -k 7")
+        print("\nerror: one of the following arguments are required: --file, --project")
         exit()
 
-    if (("Precision" in args.evaluation_measure) or ("SR" in args.evaluation_measure)) and not args.project_directory:
-        parser.print_help()
-        print("\nerror: For the Precision and the SuccessRate (SR) measures, you should use the --project flag and the ground truth microservices must be in different directories of your project's root directory.")
-        exit()
-
-if args.hard_clustering:
-    if args.threshold:
-        parser.print_help()
-        print("\nerror: The --hard-clustering flag and the --threshold flag cannot be used together.")
-        exit()
-    args.threshold = "max"
-
-measures = {"Precision": Precision, "SR": SR,
-            "SM": SM, "IFN": IFN, "NED": NED, "ICP": ICP}
-base_dir = path.dirname(path.realpath(__file__))
-
-
-def merge_java_files(src_dir, dest_file):
-    with open(dest_file, 'w') as outfile:
-        for root, dirs, files in walk(src_dir):
-            for filename in files:
-                if filename.endswith('.java'):
-                    filepath = path.join(root, filename)
-                    with open(filepath) as infile:
-                        lines = infile.readlines()
-                        for line in lines:
-                            if not line.startswith('package'):
-                                outfile.write(line)
-                    outfile.write('\n')
-
-
-if args.project_directory:
-    print("merging source files...", end="\t", flush=True)
-    if args.project_directory.endswith("/"):
-        args.project_directory = args.project_directory[:-1]
-    project_dir_name = args.project_directory.split('/')[-1]
-    true_ms_dirs = next(walk(args.project_directory))[1]
-    if path.isdir(".data/"):
-        if input("the previous data directory will be deleted; proceed? (Y/n): ") in ["n", "no", "N", "No", "NO"]:
-            print("operation cancelled.")
+    if args.evaluation_measure:
+        if bool(args.k) != ("SR" in args.evaluation_measure):
+            parser.print_help()
+            print("\nerror: The SR evaluation measure and the -k flag should always be used together to specify the k value for the SR measure. (e.g. -e SR -k 7")
             exit()
-        shutil.rmtree(".data/", ignore_errors=True)
-    true_ms_classnames = []
-    libs = path.join(base_dir, "Mo2oM/JavaParser/lib/javaparser-core-3.25.5-SNAPSHOT.jar")+pathsep+path.join(base_dir, "Mono2Multi/JavaParser/lib/json-20230618.jar")
-    makedirs(path.join(base_dir, f".data/{project_dir_name}"), exist_ok=True)
-    for directory in true_ms_dirs:
-        if directory.endswith("/"):
-            directory = directory[:-1]
-        json_path = path.join(base_dir, f".data/{project_dir_name}/{directory}.json")
-        run(['java', '-cp', libs, path.join(base_dir, 'Mo2oM/JavaParser/ClassScanner.java'), path.join(args.project_directory, directory), json_path])
-        with open(json_path, "rt") as classes_file:
-            true_ms_classnames.append(load(classes_file)["classes"])
 
-    args.file_path = path.join(base_dir, f".data/{project_dir_name}/OneFileSource.java")
-    merge_java_files(args.project_directory, args.file_path)
-    print("done!")
+        if (("Precision" in args.evaluation_measure) or ("SR" in args.evaluation_measure)) and not args.project_directory:
+            parser.print_help()
+            print("\nerror: For the Precision and the SuccessRate (SR) measures, you should use the --project flag and the ground truth microservices must be in different directories of your project's root directory.")
+            exit()
 
-print("\n--- Mo2oM ---")
+    if args.hard_clustering:
+        if args.threshold:
+            parser.print_help()
+            print("\nerror: The --hard-clustering flag and the --threshold flag cannot be used together.")
+            exit()
+        args.threshold = "max"
 
-clusters, classes_info = Mo2oM(args.file_path, args.n_clusters, args.threshold, args.alpha, args.use_tf_idf)
-class_names = list(classes_info)
-if args.project_directory:
-    true_microservices = [{-1} for _ in classes_info]
-    for i, ms in enumerate(true_ms_classnames):
-        for clss in ms:
-            true_microservices[class_names.index(clss)].add(i)
-            if -1 in true_microservices[class_names.index(clss)]:
-                true_microservices[class_names.index(clss)].discard(-1)
-    print("\nTrue Microservices:", true_microservices)
-print("\nClasses:")
-for class_number, class_name in enumerate(classes_info):
-    print(f"#{class_number}: \t{class_name}")
-output = {"microservices": [[int(_i) for _i in _] for _ in clusters]}
-print("\nClusters:")
-print(output["microservices"])
-print("\nMicroservices")
-for ms in range(max(max(_) for _ in clusters)+1):
-    print(f"ms #{ms}", [class_names[clss_i] for clss_i, ms_list in enumerate(clusters) if ms in ms_list])
-if args.evaluation_measure:
-    for measure in args.evaluation_measure:
-        if measure in ["SM", "IFN", "ICP"]:
-            print(f"{measure}: {measures[measure](clusters, classes_info)}")
-            output[measure] = measures[measure](clusters, classes_info)
-        elif measure == "Precision":
-            print(f"{measure}: {measures[measure](clusters, true_microservices)}")
-            output[measure] = measures[measure](clusters, true_microservices)
-        elif measure == "SR":
-            for k in args.k:
-                print(f"{measure}@{k}: {measures[measure](clusters, true_microservices, k)}")
-                output[measure+"@"+str(k)] = measures[measure](clusters, true_microservices, k)
-        else:
-            print(f"{measure}: {measures[measure](clusters)}")
-            output[measure] = measures[measure](clusters)
+    measures = {"Precision": Precision, "SR": SR,
+                "SM": SM, "IFN": IFN, "NED": NED, "ICP": ICP}
+    base_dir = path.dirname(path.realpath(__file__))
 
-if args.output_file:
-    with open(args.output_file, "w") as output_file:
-        dump(output, output_file, indent=2)
+
+    def merge_java_files(src_dir, dest_file):
+        with open(dest_file, 'w') as outfile:
+            for root, dirs, files in walk(src_dir):
+                for filename in files:
+                    if filename.endswith('.java'):
+                        filepath = path.join(root, filename)
+                        with open(filepath) as infile:
+                            lines = infile.readlines()
+                            for line in lines:
+                                if not line.startswith('package'):
+                                    outfile.write(line)
+                        outfile.write('\n')
+
+
+    if args.project_directory:
+        print("merging source files...", end="\t", flush=True)
+        if args.project_directory.endswith("/"):
+            args.project_directory = args.project_directory[:-1]
+        project_dir_name = args.project_directory.split('/')[-1]
+        true_ms_dirs = next(walk(args.project_directory))[1]
+        if path.isdir(".data/"):
+            if input("the previous data directory will be deleted; proceed? (Y/n): ") in ["n", "no", "N", "No", "NO"]:
+                print("operation cancelled.")
+                exit()
+            shutil.rmtree(".data/", ignore_errors=True)
+        true_ms_classnames = []
+        libs = path.join(base_dir, "Mo2oM/JavaParser/lib/javaparser-core-3.25.5-SNAPSHOT.jar")+pathsep+path.join(base_dir, "Mono2Multi/JavaParser/lib/json-20230618.jar")
+        makedirs(path.join(base_dir, f".data/{project_dir_name}"), exist_ok=True)
+        for directory in true_ms_dirs:
+            if directory.endswith("/"):
+                directory = directory[:-1]
+            json_path = path.join(base_dir, f".data/{project_dir_name}/{directory}.json")
+            run(['java', '-cp', libs, path.join(base_dir, 'Mo2oM/JavaParser/ClassScanner.java'), path.join(args.project_directory, directory), json_path])
+            with open(json_path, "rt") as classes_file:
+                true_ms_classnames.append(load(classes_file)["classes"])
+
+        args.file_path = path.join(base_dir, f".data/{project_dir_name}/OneFileSource.java")
+        merge_java_files(args.project_directory, args.file_path)
+        print("done!")
+
+    print("\n--- Mo2oM ---")
+
+    clusters, classes_info = Mo2oM(args.file_path, args.n_clusters, args.threshold, args.alpha, args.use_tf_idf)
+    class_names = list(classes_info)
+    if args.project_directory:
+        true_microservices = [{-1} for _ in classes_info]
+        for i, ms in enumerate(true_ms_classnames):
+            for clss in ms:
+                true_microservices[class_names.index(clss)].add(i)
+                if -1 in true_microservices[class_names.index(clss)]:
+                    true_microservices[class_names.index(clss)].discard(-1)
+        print("\nTrue Microservices:", true_microservices)
+    print("\nClasses:")
+    for class_number, class_name in enumerate(classes_info):
+        print(f"#{class_number}: \t{class_name}")
+    output = {"microservices": [[int(_i) for _i in _] for _ in clusters]}
+    print("\nClusters:")
+    print(output["microservices"])
+    print("\nMicroservices")
+    for ms in range(max(max(_) for _ in clusters)+1):
+        print(f"ms #{ms}", [class_names[clss_i] for clss_i, ms_list in enumerate(clusters) if ms in ms_list])
+    if args.evaluation_measure:
+        for measure in args.evaluation_measure:
+            if measure in ["SM", "IFN", "ICP"]:
+                print(f"{measure}: {measures[measure](clusters, classes_info)}")
+                output[measure] = measures[measure](clusters, classes_info)
+            elif measure == "Precision":
+                print(f"{measure}: {measures[measure](clusters, true_microservices)}")
+                output[measure] = measures[measure](clusters, true_microservices)
+            elif measure == "SR":
+                for k in args.k:
+                    print(f"{measure}@{k}: {measures[measure](clusters, true_microservices, k)}")
+                    output[measure+"@"+str(k)] = measures[measure](clusters, true_microservices, k)
+            else:
+                print(f"{measure}: {measures[measure](clusters)}")
+                output[measure] = measures[measure](clusters)
+
+    if args.output_file:
+        with open(args.output_file, "w") as output_file:
+            dump(output, output_file, indent=2)
+
+if __name__ == "__main__":
+    mp.freeze_support()
+    main()


### PR DESCRIPTION
On Windows, running Mo2oM.py crashes due to PyTorch DataLoader multiprocessing
because the script executes at import time.

This PR wraps CLI execution in a main() function and adds the standard
if __name__ == "__main__": multiprocessing.freeze_support() guard,
which prevents spawn/bootstrap errors on Windows.

Tested locally using the JPetStore example.
No behavior change on Linux/macOS.
